### PR TITLE
refactor: trim whitespace in compiler only

### DIFF
--- a/crates/brainfuck_vm/src/bin/brainfuck_vm.rs
+++ b/crates/brainfuck_vm/src/bin/brainfuck_vm.rs
@@ -29,9 +29,7 @@ fn main() {
     // Constructs a subscriber whose severity level is filtered by `RUST_LOG`
     fmt().with_env_filter(EnvFilter::from_default_env()).init();
 
-    let code = fs::read_to_string(&args.filename)
-        .expect("Failed to read file")
-        .replace(' ', "");
+    let code = fs::read_to_string(&args.filename).expect("Failed to read file");
     let mut bf_compiler = Compiler::new(code);
     let ins = bf_compiler.compile();
     tracing::info!(

--- a/crates/brainfuck_vm/src/compiler.rs
+++ b/crates/brainfuck_vm/src/compiler.rs
@@ -55,6 +55,15 @@ mod tests {
     }
 
     #[test]
+    fn test_whitespace() {
+        let code = " +  +> , < [> + .< - ]  ".to_string();
+        let compiler = Compiler::new(code);
+        let expected_trimmed_code =
+            vec!['+', '+', '>', ',', '<', '[', '>', '+', '.', '<', '-', ']'];
+        assert_eq!(expected_trimmed_code, compiler.code,);
+    }
+
+    #[test]
     fn test_compile() {
         let code = "++>,<[>+.<-]".to_string();
         let mut compiler = Compiler::new(code);

--- a/crates/brainfuck_vm/src/compiler.rs
+++ b/crates/brainfuck_vm/src/compiler.rs
@@ -51,7 +51,7 @@ mod tests {
         let compiler = Compiler::new(code);
         let expected_trimmed_code =
             vec!['+', '+', '>', ',', '<', '[', '>', '+', '.', '<', '-', ']'];
-        assert_eq!(expected_trimmed_code, compiler.code,);
+        assert_eq!(expected_trimmed_code, compiler.code);
     }
 
     #[test]
@@ -60,7 +60,7 @@ mod tests {
         let compiler = Compiler::new(code);
         let expected_trimmed_code =
             vec!['+', '+', '>', ',', '<', '[', '>', '+', '.', '<', '-', ']'];
-        assert_eq!(expected_trimmed_code, compiler.code,);
+        assert_eq!(expected_trimmed_code, compiler.code);
     }
 
     #[test]


### PR DESCRIPTION
Closes #8 

The test `test_whitespace` verifies that a given Brainfuck code string with various whitespace character (taken from the [Wikipedia article table](https://en.wikipedia.org/wiki/Whitespace_character)) are effectively trimmed (in any place of the code)