### PR TITLE
refactor: avoid panic on empty memory table when adding dummy rows

### DIFF
--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -118,6 +118,8 @@ impl MemoryTable {
     /// Fills the jumps in `clk` with dummy rows.
     ///
     /// Required to ensure the correct sorting of the [`MemoryTable`] in the constraints.
+    ///
+    /// Does nothing if the table is empty.
     fn complete_with_dummy_rows(&mut self) {
         let mut new_table = Vec::with_capacity(self.table.len());
         if let Some(mut prev_row) = self.table.first() {


### PR DESCRIPTION
Implementing the padding made me realize that the `get_row_from_index` method is completely useless

I've refactored `complete_with_dummy_rows` so that it doesn't panic if the memory table is empty, as `pad`.