### PR TITLE
feat: instruction trace padding

### DIFF
--- a/crates/brainfuck_prover/src/components/instruction/table.rs
+++ b/crates/brainfuck_prover/src/components/instruction/table.rs
@@ -87,15 +87,6 @@ impl InstructionTable {
     pub fn get_row(&self, row: &InstructionTableRow) -> Option<&InstructionTableRow> {
         self.table.iter().find(|r| *r == row)
     }
-
-    /// Retrieves the last row in the Instruction Table.
-    ///
-    /// # Returns
-    /// An `Option` containing a reference to the last [`InstructionTableRow`] in the table,
-    /// or `None` if the table is empty.
-    fn last_row(&self) -> Option<&InstructionTableRow> {
-        self.table.last()
-    }
 }
 
 impl From<(Vec<Registers>, &ProgramMemory)> for InstructionTable {
@@ -150,7 +141,7 @@ impl From<(Vec<Registers>, &ProgramMemory)> for InstructionTable {
         // - `ci` = 0 and `ni` = 0
         // TODO: execution trace may be padded with empty registers, so we need to check this case
         // in the future.
-        if let Some(last_row) = instruction_table.last_row() {
+        if let Some(last_row) = instruction_table.table.last() {
             if last_row.ci == BaseField::zero() && last_row.ni == BaseField::zero() {
                 instruction_table.table.pop();
             }
@@ -272,44 +263,6 @@ mod tests {
         let retrieved = instruction_table.get_row(&row);
         // Check that the retrieved row is None
         assert!(retrieved.is_none(), "Should return None for a non-existing row.");
-    }
-
-    #[test]
-    fn test_instruction_table_last_row() {
-        let mut instruction_table = InstructionTable::new();
-
-        // Initially, the table should be empty, so last_row should return None
-        assert!(instruction_table.last_row().is_none(), "The table should be empty initially.");
-
-        // Add a row to the table
-        let row = InstructionTableRow {
-            ip: BaseField::one(),
-            ci: BaseField::from(2),
-            ni: BaseField::from(3),
-        };
-        instruction_table.add_row(row.clone());
-
-        // Now, last_row should return a reference to the added row
-        assert_eq!(
-            instruction_table.last_row(),
-            Some(&row),
-            "The last row should match the added row."
-        );
-
-        // Add another row
-        let second_row = InstructionTableRow {
-            ip: BaseField::from(4),
-            ci: BaseField::from(5),
-            ni: BaseField::from(6),
-        };
-        instruction_table.add_row(second_row.clone());
-
-        // Now, last_row should return a reference to the second row
-        assert_eq!(
-            instruction_table.last_row(),
-            Some(&second_row),
-            "The last row should match the second added row."
-        );
     }
 
     #[test]

--- a/crates/brainfuck_prover/src/components/instruction/table.rs
+++ b/crates/brainfuck_prover/src/components/instruction/table.rs
@@ -133,15 +133,13 @@ impl From<(Vec<Registers>, &ProgramMemory)> for InstructionTable {
         let mut sorted_registers = [program, execution_trace].concat();
         sorted_registers.sort_by_key(|r| (r.ip, r.clk));
 
-        let mut instruction_table = Self::new();
+        let instruction_rows: Vec<InstructionTableRow> = sorted_registers
+            .iter()
+            .map(|reg| InstructionTableRow { ip: reg.ip, ci: reg.ci, ni: reg.ni })
+            .collect();
 
-        for register in &sorted_registers {
-            instruction_table.add_row(InstructionTableRow {
-                ip: register.ip,
-                ci: register.ci,
-                ni: register.ni,
-            });
-        }
+        let mut instruction_table = Self::new();
+        instruction_table.add_rows(instruction_rows);
 
         instruction_table.pad();
 
@@ -291,8 +289,17 @@ mod tests {
         // Convert the trace to an `InstructionTable`
         let instruction_table: InstructionTable = (trace, machine.program()).into();
 
+        let padded_rows = vec![
+            InstructionTableRow {
+                ip: BaseField::from(13),
+                ci: BaseField::zero(),
+                ni: BaseField::zero(),
+            };
+            10
+        ];
+
         // Create the expected `InstructionTable`
-        let expected_instruction_table = InstructionTable {
+        let mut expected_instruction_table = InstructionTable {
             table: vec![
                 InstructionTableRow {
                     ip: BaseField::from(0),
@@ -406,6 +413,8 @@ mod tests {
                 },
             ],
         };
+
+        expected_instruction_table.add_rows(padded_rows);
 
         // Verify that the instruction table is correct
         assert_eq!(instruction_table, expected_instruction_table);
@@ -429,7 +438,15 @@ mod tests {
         // Convert the trace to an `InstructionTable`
         let instruction_table: InstructionTable = (trace, machine.program()).into();
 
-        let expected_instruction_table = InstructionTable {
+        let padded_rows = vec![
+            InstructionTableRow {
+                ip: BaseField::from(5),
+                ci: BaseField::zero(),
+                ni: BaseField::zero(),
+            };
+            4
+        ];
+        let mut expected_instruction_table = InstructionTable {
             table: vec![
                 InstructionTableRow {
                     ip: BaseField::zero(),
@@ -453,6 +470,8 @@ mod tests {
                 },
             ],
         };
+
+        expected_instruction_table.add_rows(padded_rows);
 
         // Verify that the instruction table is correct
         assert_eq!(instruction_table, expected_instruction_table);

--- a/crates/brainfuck_prover/src/components/instruction/table.rs
+++ b/crates/brainfuck_prover/src/components/instruction/table.rs
@@ -106,7 +106,6 @@ impl InstructionTable {
 }
 
 impl From<(Vec<Registers>, &ProgramMemory)> for InstructionTable {
-    #[allow(clippy::cast_lossless)]
     fn from((execution_trace, program_memory): (Vec<Registers>, &ProgramMemory)) -> Self {
         let mut program = Vec::new();
 
@@ -273,7 +272,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cast_lossless, clippy::too_many_lines)]
     fn test_instruction_table_from_registers_example_program() {
         // Create a small program and compile it
         let code = "+>,<[>+.<-]";
@@ -289,6 +287,66 @@ mod tests {
         // Convert the trace to an `InstructionTable`
         let instruction_table: InstructionTable = (trace, machine.program()).into();
 
+        // Create the expected `InstructionTable`
+        let ins_0 = InstructionTableRow {
+            ip: BaseField::zero(),
+            ci: INCREMENT_INSTRUCTION_BF,
+            ni: SHIFT_RIGHT_INSTRUCTION_BF,
+        };
+
+        let ins_1 = InstructionTableRow {
+            ip: BaseField::one(),
+            ci: SHIFT_RIGHT_INSTRUCTION_BF,
+            ni: INPUT_INSTRUCTION_BF,
+        };
+
+        let ins_2 = InstructionTableRow {
+            ip: BaseField::from(2),
+            ci: INPUT_INSTRUCTION_BF,
+            ni: SHIFT_LEFT_INSTRUCTION_BF,
+        };
+
+        let ins_3 = InstructionTableRow {
+            ip: BaseField::from(3),
+            ci: SHIFT_LEFT_INSTRUCTION_BF,
+            ni: JUMP_IF_ZERO_INSTRUCTION_BF,
+        };
+        let ins_4 = InstructionTableRow {
+            ip: BaseField::from(4),
+            ci: JUMP_IF_ZERO_INSTRUCTION_BF,
+            ni: BaseField::from(12),
+        };
+        let ins_6 = InstructionTableRow {
+            ip: BaseField::from(6),
+            ci: SHIFT_RIGHT_INSTRUCTION_BF,
+            ni: INCREMENT_INSTRUCTION_BF,
+        };
+        let ins_7 = InstructionTableRow {
+            ip: BaseField::from(7),
+            ci: INCREMENT_INSTRUCTION_BF,
+            ni: OUTPUT_INSTRUCTION_BF,
+        };
+        let ins_8 = InstructionTableRow {
+            ip: BaseField::from(8),
+            ci: OUTPUT_INSTRUCTION_BF,
+            ni: SHIFT_LEFT_INSTRUCTION_BF,
+        };
+        let ins_9 = InstructionTableRow {
+            ip: BaseField::from(9),
+            ci: SHIFT_LEFT_INSTRUCTION_BF,
+            ni: DECREMENT_INSTRUCTION_BF,
+        };
+        let inst_10 = InstructionTableRow {
+            ip: BaseField::from(10),
+            ci: DECREMENT_INSTRUCTION_BF,
+            ni: JUMP_IF_NON_ZERO_INSTRUCTION_BF,
+        };
+        let ins_11 = InstructionTableRow {
+            ip: BaseField::from(11),
+            ci: JUMP_IF_NON_ZERO_INSTRUCTION_BF,
+            ni: BaseField::from(6),
+        };
+
         let padded_rows = vec![
             InstructionTableRow {
                 ip: BaseField::from(13),
@@ -298,119 +356,30 @@ mod tests {
             10
         ];
 
-        // Create the expected `InstructionTable`
         let mut expected_instruction_table = InstructionTable {
             table: vec![
-                InstructionTableRow {
-                    ip: BaseField::from(0),
-                    ci: INCREMENT_INSTRUCTION_BF,
-                    ni: SHIFT_RIGHT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(0),
-                    ci: INCREMENT_INSTRUCTION_BF,
-                    ni: SHIFT_RIGHT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(1),
-                    ci: SHIFT_RIGHT_INSTRUCTION_BF,
-                    ni: INPUT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(1),
-                    ci: SHIFT_RIGHT_INSTRUCTION_BF,
-                    ni: INPUT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(2),
-                    ci: INPUT_INSTRUCTION_BF,
-                    ni: SHIFT_LEFT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(2),
-                    ci: INPUT_INSTRUCTION_BF,
-                    ni: SHIFT_LEFT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(3),
-                    ci: SHIFT_LEFT_INSTRUCTION_BF,
-                    ni: JUMP_IF_ZERO_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(3),
-                    ci: SHIFT_LEFT_INSTRUCTION_BF,
-                    ni: JUMP_IF_ZERO_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(4),
-                    ci: JUMP_IF_ZERO_INSTRUCTION_BF,
-                    ni: BaseField::from(12),
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(4),
-                    ci: JUMP_IF_ZERO_INSTRUCTION_BF,
-                    ni: BaseField::from(12),
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(6),
-                    ci: SHIFT_RIGHT_INSTRUCTION_BF,
-                    ni: INCREMENT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(6),
-                    ci: SHIFT_RIGHT_INSTRUCTION_BF,
-                    ni: INCREMENT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(7),
-                    ci: INCREMENT_INSTRUCTION_BF,
-                    ni: OUTPUT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(7),
-                    ci: INCREMENT_INSTRUCTION_BF,
-                    ni: OUTPUT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(8),
-                    ci: OUTPUT_INSTRUCTION_BF,
-                    ni: SHIFT_LEFT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(8),
-                    ci: OUTPUT_INSTRUCTION_BF,
-                    ni: SHIFT_LEFT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(9),
-                    ci: SHIFT_LEFT_INSTRUCTION_BF,
-                    ni: DECREMENT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(9),
-                    ci: SHIFT_LEFT_INSTRUCTION_BF,
-                    ni: DECREMENT_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(10),
-                    ci: DECREMENT_INSTRUCTION_BF,
-                    ni: JUMP_IF_NON_ZERO_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(10),
-                    ci: DECREMENT_INSTRUCTION_BF,
-                    ni: JUMP_IF_NON_ZERO_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(11),
-                    ci: JUMP_IF_NON_ZERO_INSTRUCTION_BF,
-                    ni: BaseField::from(6),
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(11),
-                    ci: JUMP_IF_NON_ZERO_INSTRUCTION_BF,
-                    ni: BaseField::from(6),
-                },
+                ins_0.clone(),
+                ins_0,
+                ins_1.clone(),
+                ins_1,
+                ins_2.clone(),
+                ins_2,
+                ins_3.clone(),
+                ins_3,
+                ins_4.clone(),
+                ins_4,
+                ins_6.clone(),
+                ins_6,
+                ins_7.clone(),
+                ins_7,
+                ins_8.clone(),
+                ins_8,
+                ins_9.clone(),
+                ins_9,
+                inst_10.clone(),
+                inst_10,
+                ins_11.clone(),
+                ins_11,
             ],
         };
 
@@ -421,7 +390,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cast_lossless)]
     fn test_instruction_table_program_unused_instruction() {
         // We chose a simple program that has unused instructions
         // The goal is to verify that the merge between the trace and the program is correct
@@ -438,6 +406,24 @@ mod tests {
         // Convert the trace to an `InstructionTable`
         let instruction_table: InstructionTable = (trace, machine.program()).into();
 
+        let ins_0 = InstructionTableRow {
+            ip: BaseField::zero(),
+            ci: JUMP_IF_ZERO_INSTRUCTION_BF,
+            ni: BaseField::from(4),
+        };
+
+        let ins_2 = InstructionTableRow {
+            ip: BaseField::from(2),
+            ci: DECREMENT_INSTRUCTION_BF,
+            ni: JUMP_IF_NON_ZERO_INSTRUCTION_BF,
+        };
+
+        let ins_3 = InstructionTableRow {
+            ip: BaseField::from(3),
+            ci: JUMP_IF_NON_ZERO_INSTRUCTION_BF,
+            ni: BaseField::from(2),
+        };
+
         let padded_rows = vec![
             InstructionTableRow {
                 ip: BaseField::from(5),
@@ -446,30 +432,8 @@ mod tests {
             };
             4
         ];
-        let mut expected_instruction_table = InstructionTable {
-            table: vec![
-                InstructionTableRow {
-                    ip: BaseField::zero(),
-                    ci: JUMP_IF_ZERO_INSTRUCTION_BF,
-                    ni: BaseField::from(4),
-                },
-                InstructionTableRow {
-                    ip: BaseField::zero(),
-                    ci: JUMP_IF_ZERO_INSTRUCTION_BF,
-                    ni: BaseField::from(4),
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(2),
-                    ci: DECREMENT_INSTRUCTION_BF,
-                    ni: JUMP_IF_NON_ZERO_INSTRUCTION_BF,
-                },
-                InstructionTableRow {
-                    ip: BaseField::from(3),
-                    ci: JUMP_IF_NON_ZERO_INSTRUCTION_BF,
-                    ni: BaseField::from(2),
-                },
-            ],
-        };
+        let mut expected_instruction_table =
+            InstructionTable { table: vec![ins_0.clone(), ins_0, ins_2, ins_3] };
 
         expected_instruction_table.add_rows(padded_rows);
 

--- a/crates/brainfuck_prover/src/components/instruction/table.rs
+++ b/crates/brainfuck_prover/src/components/instruction/table.rs
@@ -108,15 +108,11 @@ impl InstructionTable {
 impl From<(Vec<Registers>, &ProgramMemory)> for InstructionTable {
     #[allow(clippy::cast_lossless)]
     fn from((execution_trace, program_memory): (Vec<Registers>, &ProgramMemory)) -> Self {
-        // Create an empty vector to store the program instructions.
         let mut program = Vec::new();
 
-        // Extract the program's code from the `ProgramMemory`.
         let code = program_memory.code();
 
-        // Iterate over the code and collect valid instructions.
         for (index, ci) in code.iter().enumerate() {
-            // Skip invalid instructions.
             if !VALID_INSTRUCTIONS.contains(ci) {
                 continue;
             }
@@ -134,18 +130,12 @@ impl From<(Vec<Registers>, &ProgramMemory)> for InstructionTable {
             });
         }
 
-        // Concatenate the program's instructions with the provided execution trace.
         let mut sorted_registers = [program, execution_trace].concat();
-        // Sort the registers by:
-        // 1. `ip` (instruction pointer)
-        // 2. `clk` (clock cycle)
         sorted_registers.sort_by_key(|r| (r.ip, r.clk));
 
-        // Initialize a new instruction table to store the sorted and processed rows.
         let mut instruction_table = Self::new();
 
         for register in &sorted_registers {
-            // Add the current register to the instruction table.
             instruction_table.add_row(InstructionTableRow {
                 ip: register.ip,
                 ci: register.ci,
@@ -155,7 +145,6 @@ impl From<(Vec<Registers>, &ProgramMemory)> for InstructionTable {
 
         instruction_table.pad();
 
-        // Return the fully constructed and populated instruction table.
         instruction_table
     }
 }


### PR DESCRIPTION
Closes #53 

It also includes a small refactor of the instruction table test, moving instructions to a variable as they are used multiple times.
For consistency, I've also done it in the test `test_instruction_table_program_unused_instruction` for both instructions that are used once.

I feel like it is clearer this way: one could read the ci/ni fields and know what the program does, and we clearly see the multiplicity of instructions $m + 1$ where $m$ is the number of times an instruction is executed.