### PR TITLE
refactor: memory table cleanup

### DIFF
--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -142,8 +142,7 @@ impl From<Vec<Registers>> for MemoryTable {
     fn from(registers: Vec<Registers>) -> Self {
         let mut memory_table = Self::new();
 
-        let memory_rows: Vec<MemoryTableRow> =
-            registers.iter().map(|reg| MemoryTableRow::from((reg, false))).collect();
+        let memory_rows = registers.iter().map(|reg| (reg, false).into()).collect();
         memory_table.add_rows(memory_rows);
 
         memory_table.sort();


### PR DESCRIPTION
Removes unnecessary methods from MemoryTable, makes fields and methods private.

It also refactors the way registers are added to the memory table in From<Vec<Registers>> for MemoryTable

I'm half convinced of the proposed design to create MemoryTableRow out of Registers, with `From<(&Register, bool)> for MemorytTableRow`