### PR TITLE
feat: add memory trace prove entrypoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "brainfuck_vm",
  "num-traits",
  "stwo-prover",
+ "thiserror 2.0.0",
 ]
 
 [[package]]

--- a/crates/brainfuck_prover/Cargo.toml
+++ b/crates/brainfuck_prover/Cargo.toml
@@ -12,3 +12,4 @@ workspace = true
 brainfuck_vm.workspace = true
 stwo-prover.workspace = true
 num-traits.workspace = true
+thiserror.workspace = true

--- a/crates/brainfuck_prover/src/brainfuck_air/mod.rs
+++ b/crates/brainfuck_prover/src/brainfuck_air/mod.rs
@@ -1,4 +1,4 @@
-use crate::components::memory;
+use crate::components::memory::{self, table::MemoryTable};
 use brainfuck_vm::machine::Machine;
 use stwo_prover::core::{
     air::{Component, ComponentProver},
@@ -130,8 +130,7 @@ pub fn prove_brainfuck(
     // └───────────────────────────────────────┘
     let vm_trace = inputs.get_trace();
 
-    let (memory_trace, memory_claim) =
-        memory::table::get_trace_evaluation(&vm_trace.into()).unwrap();
+    let (memory_trace, memory_claim) = MemoryTable::from(vm_trace).trace_evaluation().unwrap();
 
     tree_builder.extend_evals(memory_trace);
 

--- a/crates/brainfuck_prover/src/brainfuck_air/mod.rs
+++ b/crates/brainfuck_prover/src/brainfuck_air/mod.rs
@@ -131,7 +131,8 @@ pub fn prove_brainfuck(
     // └───────────────────────────────────────┘
     let vm_trace = inputs.get_trace();
 
-    let (memory_trace, memory_claim) = memory::table::write_trace(&vm_trace.into()).unwrap();
+    let (memory_trace, memory_claim) =
+        memory::table::get_trace_evaluation(&vm_trace.into()).unwrap();
 
     tree_builder.extend_evals(memory_trace);
 

--- a/crates/brainfuck_prover/src/brainfuck_air/mod.rs
+++ b/crates/brainfuck_prover/src/brainfuck_air/mod.rs
@@ -1,3 +1,4 @@
+use brainfuck_vm::machine::Machine;
 use stwo_prover::core::{
     air::{Component, ComponentProver},
     backend::simd::SimdBackend,
@@ -10,6 +11,8 @@ use stwo_prover::core::{
         ops::MerkleHasher,
     },
 };
+
+use crate::components::memory;
 
 /// The STARK proof of the execution of a given Brainfuck program.
 ///
@@ -24,15 +27,17 @@ pub struct BrainfuckProof<H: MerkleHasher> {
 ///
 /// It includes the common claim values such as the initial and final states
 /// and the claim of each component.
-pub struct BrainfuckClaim;
+pub struct BrainfuckClaim {
+    pub memory: memory::component::Claim,
+}
 
 impl BrainfuckClaim {
-    pub fn mix_into(&self, _channel: &mut impl Channel) {
-        todo!();
+    pub fn mix_into(&self, channel: &mut impl Channel) {
+        self.memory.mix_into(channel);
     }
 
     pub fn log_sizes(&self) -> TreeVec<Vec<u32>> {
-        todo!();
+        self.memory.log_sizes()
     }
 }
 
@@ -93,12 +98,14 @@ impl BrainfuckComponents {
     }
 }
 
-/// `LOG_MAX_ROWS = log2(MAX_ROWS)` ?
+/// `LOG_MAX_ROWS = ilog2(MAX_ROWS)`
 ///
 /// Means that the ZK-VM does not accept programs with more than 2^20 steps (1M steps).
 const LOG_MAX_ROWS: u32 = 20;
 
-pub fn prove_brainfuck() -> Result<BrainfuckProof<Blake2sMerkleHasher>, ProvingError> {
+pub fn prove_brainfuck(
+    inputs: Machine,
+) -> Result<BrainfuckProof<Blake2sMerkleHasher>, ProvingError> {
     // ┌──────────────────────────┐
     // │     Protocol Setup       │
     // └──────────────────────────┘
@@ -112,22 +119,26 @@ pub fn prove_brainfuck() -> Result<BrainfuckProof<Blake2sMerkleHasher>, ProvingE
     let channel = &mut Blake2sChannel::default();
     let commitment_scheme =
         &mut CommitmentSchemeProver::<_, Blake2sMerkleChannel>::new(config, &twiddles);
-    let tree_builder = commitment_scheme.tree_builder();
+    let mut tree_builder = commitment_scheme.tree_builder();
 
-    // ┌──────────────────────────┐
-    // │   Interaction Phase 0    │
-    // └──────────────────────────┘
+    // ┌───────────────────────────────────────┐
+    // │    Interaction Phase 0 - Main Trace   │
+    // └───────────────────────────────────────┘
+    let vm_trace = inputs.get_trace();
 
-    // Generate BrainfuckClaim (from the execution trace provided by brainfuck_vm)
+    let (memory_trace, memory_claim) = memory::table::write_trace(&vm_trace.into()).unwrap();
+
+    tree_builder.extend_evals(memory_trace);
+
+    let claim = BrainfuckClaim { memory: memory_claim };
 
     // Commit to the claim and the trace.
-    let claim = BrainfuckClaim {};
     claim.mix_into(channel);
     tree_builder.commit(channel);
 
-    // ┌──────────────────────────┐
-    // │   Interaction Phase 1    │
-    // └──────────────────────────┘
+    // ┌───────────────────────────────────────────────┐
+    // │    Interaction Phase 1 - Interaction Trace    │
+    // └───────────────────────────────────────────────┘
 
     // Draw interaction elements
     let interaction_elements = BrainfuckInteractionElements::draw(channel);
@@ -139,9 +150,10 @@ pub fn prove_brainfuck() -> Result<BrainfuckProof<Blake2sMerkleHasher>, ProvingE
     interaction_claim.mix_into(channel);
     tree_builder.commit(channel);
 
-    // ┌──────────────────────────┐
-    // │   Interaction Phase 2    │
-    // └──────────────────────────┘
+    // TODO: move the preprocessed trace to Phase 0
+    // ┌───────────────────────────────────────────────┐
+    // │   Interaction Phase 2 - Preprocessed Trace    │
+    // └───────────────────────────────────────────────┘
 
     // Generate constant columns (e.g. is_first)
     let tree_builder = commitment_scheme.tree_builder();

--- a/crates/brainfuck_prover/src/brainfuck_air/mod.rs
+++ b/crates/brainfuck_prover/src/brainfuck_air/mod.rs
@@ -1,3 +1,4 @@
+use crate::components::memory;
 use brainfuck_vm::machine::Machine;
 use stwo_prover::core::{
     air::{Component, ComponentProver},
@@ -11,8 +12,6 @@ use stwo_prover::core::{
         ops::MerkleHasher,
     },
 };
-
-use crate::components::memory;
 
 /// The STARK proof of the execution of a given Brainfuck program.
 ///

--- a/crates/brainfuck_prover/src/brainfuck_air/mod.rs
+++ b/crates/brainfuck_prover/src/brainfuck_air/mod.rs
@@ -109,7 +109,7 @@ const LOG_MAX_ROWS: u32 = 20;
 /// * `inputs` - The [`Machine`] struct after the program execution
 /// The inputs contains the program, the memory, the I/O and the trace.
 pub fn prove_brainfuck(
-    inputs: Machine,
+    inputs: &Machine,
 ) -> Result<BrainfuckProof<Blake2sMerkleHasher>, ProvingError> {
     // ┌──────────────────────────┐
     // │     Protocol Setup       │

--- a/crates/brainfuck_prover/src/brainfuck_air/mod.rs
+++ b/crates/brainfuck_prover/src/brainfuck_air/mod.rs
@@ -103,6 +103,11 @@ impl BrainfuckComponents {
 /// Means that the ZK-VM does not accept programs with more than 2^20 steps (1M steps).
 const LOG_MAX_ROWS: u32 = 20;
 
+/// Generate a STARK proof of the given Brainfuck program execution.
+///
+/// # Arguments
+/// * `inputs` - The [`Machine`] struct after the program execution
+/// The inputs contains the program, the memory, the I/O and the trace.
 pub fn prove_brainfuck(
     inputs: Machine,
 ) -> Result<BrainfuckProof<Blake2sMerkleHasher>, ProvingError> {

--- a/crates/brainfuck_prover/src/components/memory/component.rs
+++ b/crates/brainfuck_prover/src/components/memory/component.rs
@@ -1,18 +1,36 @@
-use stwo_prover::core::{channel::Channel, pcs::TreeVec};
-
 use super::table::N_COLS_MEMORY_TABLE;
+use stwo_prover::core::{channel::Channel, pcs::TreeVec};
 
 /// The claim for the Memory component
 #[derive(Debug, Eq, PartialEq)]
 pub struct Claim {
     pub log_size: u32,
 }
+
 impl Claim {
+    /// Returns the log_size of the each type of trace commited for the Memory component:
+    /// - Preprocessed trace,
+    /// - Main trace,
+    /// - Interaction trace.
+    ///
+    /// The number of columns of each trace is known before actually evaluating them.
+    /// The `log_size` is known once the main trace has been evaluated
+    /// (the log2 of the size of the [`super::table::MemoryTable`], to which we add LOG_N_LANES for
+    /// the SimdBackend)
+    ///
+    /// Each element of the [`TreeVec`] is dedicated to the commitment of one type of trace.
+    /// First element is for the preprocessed trace, second for the main trace and third for the
+    /// interaction one.
+    ///
+    /// NOTE: Currently only the main trace is provided.
     pub fn log_sizes(&self) -> TreeVec<Vec<u32>> {
+        // TODO: Add the preprocessed and interaction trace sizes
         let trace_log_sizes = vec![self.log_size; N_COLS_MEMORY_TABLE];
         TreeVec::new(vec![trace_log_sizes])
     }
 
+    /// Mix the log size of the Memory table to the Fiat-Shamir channel,
+    /// to bound the channel randomness and the trace.
     pub fn mix_into(&self, channel: &mut impl Channel) {
         channel.mix_u64(u64::from(self.log_size));
     }

--- a/crates/brainfuck_prover/src/components/memory/component.rs
+++ b/crates/brainfuck_prover/src/components/memory/component.rs
@@ -3,7 +3,7 @@ use stwo_prover::core::{channel::Channel, pcs::TreeVec};
 use super::table::N_COLS_MEMORY_TABLE;
 
 /// The claim for the Memory component
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Claim {
     pub log_size: u32,
 }
@@ -14,6 +14,6 @@ impl Claim {
     }
 
     pub fn mix_into(&self, channel: &mut impl Channel) {
-        channel.mix_u64(self.log_size as u64);
+        channel.mix_u64(u64::from(self.log_size));
     }
 }

--- a/crates/brainfuck_prover/src/components/memory/component.rs
+++ b/crates/brainfuck_prover/src/components/memory/component.rs
@@ -1,0 +1,19 @@
+use stwo_prover::core::{channel::Channel, pcs::TreeVec};
+
+use super::table::N_COLS_MEMORY_TABLE;
+
+/// The claim for the Memory component
+#[derive(Debug, PartialEq)]
+pub struct Claim {
+    pub log_size: u32,
+}
+impl Claim {
+    pub fn log_sizes(&self) -> TreeVec<Vec<u32>> {
+        let trace_log_sizes = vec![self.log_size; N_COLS_MEMORY_TABLE];
+        TreeVec::new(vec![trace_log_sizes])
+    }
+
+    pub fn mix_into(&self, channel: &mut impl Channel) {
+        channel.mix_u64(self.log_size as u64);
+    }
+}

--- a/crates/brainfuck_prover/src/components/memory/component.rs
+++ b/crates/brainfuck_prover/src/components/memory/component.rs
@@ -8,15 +8,16 @@ pub struct Claim {
 }
 
 impl Claim {
-    /// Returns the log_size of the each type of trace commited for the Memory component:
+    /// Returns the `log_size` of the each type of trace commited for the Memory component:
     /// - Preprocessed trace,
     /// - Main trace,
     /// - Interaction trace.
     ///
     /// The number of columns of each trace is known before actually evaluating them.
     /// The `log_size` is known once the main trace has been evaluated
-    /// (the log2 of the size of the [`super::table::MemoryTable`], to which we add LOG_N_LANES for
-    /// the SimdBackend)
+    /// (the log2 of the size of the [`super::table::MemoryTable`], to which we add
+    /// [`stwo_prover::core::backend::simd::m31::LOG_N_LANES`]
+    /// for the [`stwo_prover::core::backend::simd::SimdBackend`])
     ///
     /// Each element of the [`TreeVec`] is dedicated to the commitment of one type of trace.
     /// First element is for the preprocessed trace, second for the main trace and third for the
@@ -29,9 +30,9 @@ impl Claim {
         TreeVec::new(vec![trace_log_sizes])
     }
 
-    /// Mix the log size of the Memory table to the Fiat-Shamir channel,
+    /// Mix the log size of the Memory table to the Fiat-Shamir [`Channel`],
     /// to bound the channel randomness and the trace.
     pub fn mix_into(&self, channel: &mut impl Channel) {
-        channel.mix_u64(u64::from(self.log_size));
+        channel.mix_u64(self.log_size.into());
     }
 }

--- a/crates/brainfuck_prover/src/components/memory/mod.rs
+++ b/crates/brainfuck_prover/src/components/memory/mod.rs
@@ -1,1 +1,2 @@
+pub mod component;
 pub mod table;

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -189,6 +189,14 @@ pub enum TraceError {
     EmptyTraceError,
 }
 
+/// Transforms the [`MemoryTable`] into [`Trace`], to be commited when generating a STARK proof.
+///
+/// The [`MemoryTable`] is transformed from an array of rows (one element = one step of all
+/// registers) to an array of columns (one element = all steps of one register).
+/// It is then evaluated on the circle domain.
+///
+/// # Arguments
+/// * memory - The [`MemoryTable`] containing the sorted and padded trace as an array of rows.
 pub fn write_trace(memory: &MemoryTable) -> Result<(Trace, Claim), TraceError> {
     let n_rows = memory.table.len() as u32;
     if n_rows == 0 {

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -175,7 +175,8 @@ const MV_COL_INDEX: usize = 2;
 /// Index of the `d` register column in the Memory trace.
 const D_COL_INDEX: usize = 3;
 
-/// Transforms the [`MemoryTable`] into [`Trace`], to be commited when generating a STARK proof.
+/// Transforms the [`MemoryTable`] into [`super::super::TraceEval`], to be commited when generating
+/// a STARK proof.
 ///
 /// The [`MemoryTable`] is transformed from an array of rows (one element = one step of all
 /// registers) to an array of columns (one element = all steps of one register).

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -1,3 +1,5 @@
+use super::component::Claim;
+use crate::components::{TraceError, TraceEval};
 use brainfuck_vm::registers::Registers;
 use num_traits::One;
 use stwo_prover::core::{
@@ -8,10 +10,6 @@ use stwo_prover::core::{
     fields::m31::BaseField,
     poly::circle::{CanonicCoset, CircleEvaluation},
 };
-
-use crate::components::{TraceError, TraceEval};
-
-use super::component::Claim;
 
 /// Represents a single row in the Memory Table.
 ///
@@ -223,7 +221,7 @@ pub fn get_trace_evaluation(memory: &MemoryTable) -> Result<(TraceEval, Claim), 
     let table = memory.table();
     let n_rows = table.len() as u32;
     if n_rows == 0 {
-        return Err(TraceError::EmptyTraceError);
+        return Err(TraceError::EmptyTrace);
     }
     let log_n_rows = n_rows.ilog2();
     // TODO: Confirm that the log_size used for evaluation on Circle domain is the log_size of the
@@ -477,6 +475,6 @@ mod tests {
         let memory_table = MemoryTable::new();
         let run = get_trace_evaluation(&memory_table);
 
-        assert!(matches!(run, Err(TraceError::EmptyTraceError)));
+        assert!(matches!(run, Err(TraceError::EmptyTrace)));
     }
 }

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -206,8 +206,8 @@ pub fn write_trace(memory: &MemoryTable) -> Result<(TraceEval, Claim), TraceErro
     let domain = CanonicCoset::new(log_size).circle_domain();
     let trace = trace.into_iter().map(|col| CircleEvaluation::new(domain, col)).collect();
 
-    // TODO: Confirm that the log_size in `Claim` is `log_n_rows`
-    Ok((trace, Claim { log_size: log_n_rows }))
+    // TODO: Confirm that the log_size in `Claim` is `log_size`, including the SIMD lanes
+    Ok((trace, Claim { log_size }))
 }
 
 #[cfg(test)]
@@ -428,7 +428,7 @@ mod tests {
             .into_iter()
             .map(|col| CircleEvaluation::new(domain, col))
             .collect();
-        let expected_claim = Claim { log_size: expected_log_n_rows };
+        let expected_claim = Claim { log_size: expected_log_size };
 
         assert_eq!(claim, expected_claim);
         for col_index in 0..expected_trace.len() {

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -182,7 +182,7 @@ const D_COL_INDEX: usize = 3;
 pub type Trace = ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>;
 
 /// Custom error type for the Trace.
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error, Eq, PartialEq)]
 pub enum TraceError {
     /// The component trace is empty.
     #[error("The trace is empty.")]
@@ -420,10 +420,10 @@ mod tests {
         let expected_log_n_rows: u32 = 1;
         let expected_log_size = expected_log_n_rows + LOG_N_LANES;
         let expected_size = 1 << expected_log_size;
-        let mut clk_column: BaseColumn = BaseColumn::zeros(expected_size);
-        let mut mp_column: BaseColumn = BaseColumn::zeros(expected_size);
-        let mut mv_col: BaseColumn = BaseColumn::zeros(expected_size);
-        let mut d_column: BaseColumn = BaseColumn::zeros(expected_size);
+        let mut clk_column = BaseColumn::zeros(expected_size);
+        let mut mp_column = BaseColumn::zeros(expected_size);
+        let mut mv_col = BaseColumn::zeros(expected_size);
+        let mut d_column = BaseColumn::zeros(expected_size);
 
         clk_column.data[0] = BaseField::zero().into();
         clk_column.data[1] = BaseField::one().into();

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -52,22 +52,22 @@ impl MemoryTableRow {
     }
 
     /// Getter for the `clk` field.
-    pub fn clk(&self) -> BaseField {
+    pub const fn clk(&self) -> BaseField {
         self.clk
     }
 
     /// Getter for the `mp` field.
-    pub fn mp(&self) -> BaseField {
+    pub const fn mp(&self) -> BaseField {
         self.mp
     }
 
     /// Getter for the `mv` field.
-    pub fn mv(&self) -> BaseField {
+    pub const fn mv(&self) -> BaseField {
         self.mv
     }
 
     /// Getter for the `d` field.
-    pub fn d(&self) -> BaseField {
+    pub const fn d(&self) -> BaseField {
         self.d
     }
 }
@@ -106,8 +106,8 @@ impl MemoryTable {
         Self::default()
     }
 
-    /// Getter for the `table`field.`
-    pub fn table(&self) -> &Vec<MemoryTableRow> {
+    /// Getter for the `table` field.
+    pub const fn table(&self) -> &Vec<MemoryTableRow> {
         &self.table
     }
 
@@ -232,8 +232,7 @@ pub fn get_trace_evaluation(memory: &MemoryTable) -> Result<(TraceEval, Claim), 
     let mut trace: Vec<BaseColumn> =
         (0..N_COLS_MEMORY_TABLE).map(|_| BaseColumn::zeros(1 << log_size)).collect();
 
-    for vec_row in 0..1 << (log_n_rows) {
-        let row = &table[vec_row];
+    for (vec_row, row) in table.iter().enumerate().take(1 << log_n_rows) {
         trace[CLK_COL_INDEX].data[vec_row] = row.clk().into();
         trace[MP_COL_INDEX].data[vec_row] = row.mp().into();
         trace[MV_COL_INDEX].data[vec_row] = row.mv().into();

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -33,10 +33,20 @@ pub struct MemoryTableRow {
 }
 
 impl MemoryTableRow {
+    /// Creates a row for the [`MemoryTable`] which is considered 'real'.
+    ///
+    /// A 'real' row, is a row that is part of the execution trace from the Brainfuck program
+    /// execution.
     pub fn new(clk: BaseField, mp: BaseField, mv: BaseField) -> Self {
         Self { clk, mp, mv, ..Default::default() }
     }
 
+    /// Creates a row for the [`MemoryTable`] which is considered 'dummy'.
+    ///
+    /// A 'dummy' row, is a row that is not part of the execution trace from the Brainfuck program
+    /// execution.
+    /// They are used for padding and filling the `clk` gaps after sorting by `mp`, to enforce the
+    /// correct sorting.
     pub fn new_dummy(clk: BaseField, mp: BaseField, mv: BaseField) -> Self {
         Self { clk, mp, mv, d: BaseField::one() }
     }

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -417,8 +417,8 @@ mod tests {
 
         let (trace, claim) = write_trace(&memory_table).unwrap();
 
-        let expected_n_rows: u32 = 2;
-        let expected_log_size = expected_n_rows.ilog2() + LOG_N_LANES;
+        let expected_log_n_rows: u32 = 1;
+        let expected_log_size = expected_log_n_rows + LOG_N_LANES;
         let expected_size = 1 << expected_log_size;
         let mut clk_column: BaseColumn = BaseColumn::zeros(expected_size);
         let mut mp_column: BaseColumn = BaseColumn::zeros(expected_size);
@@ -442,7 +442,7 @@ mod tests {
             .into_iter()
             .map(|col| CircleEvaluation::new(domain, col))
             .collect();
-        let expected_claim = Claim { log_size: expected_n_rows };
+        let expected_claim = Claim { log_size: expected_log_n_rows };
 
         assert_eq!(claim, expected_claim);
         for col_index in 0..expected_trace.len() {

--- a/crates/brainfuck_prover/src/components/mod.rs
+++ b/crates/brainfuck_prover/src/components/mod.rs
@@ -18,5 +18,5 @@ pub type TraceEval = ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitRever
 pub enum TraceError {
     /// The component trace is empty.
     #[error("The trace is empty.")]
-    EmptyTraceError,
+    EmptyTrace,
 }

--- a/crates/brainfuck_prover/src/components/mod.rs
+++ b/crates/brainfuck_prover/src/components/mod.rs
@@ -1,3 +1,22 @@
+use stwo_prover::core::{
+    backend::simd::SimdBackend,
+    fields::m31::BaseField,
+    poly::{circle::CircleEvaluation, BitReversedOrder},
+    ColumnVec,
+};
+use thiserror::Error;
+
 pub mod instruction;
 pub mod io;
 pub mod memory;
+
+/// Type for trace evaluation to be used in Stwo.
+pub type TraceEval = ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>;
+
+/// Custom error type for the Trace.
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum TraceError {
+    /// The component trace is empty.
+    #[error("The trace is empty.")]
+    EmptyTraceError,
+}


### PR DESCRIPTION
Closes #55

The `write_trace` function is in the `table.rs` file to access the private fields of `MemoryTable` and `MemoryTableRow`, but it might be better to refactor it into its own file?

The conversion from `MemoryTable` to `Vec<BaseColumn>` and the evaluation on the circle domain could be refactored into two separate functions, to be used in the `write_trace` function.

The name `write_trace` might be misleading as we're not writing the trace to a tree but simply returning the Trace evaluation and the Claim on its size. (We could add the tree to which the trace evaluation should be written to as parameter and do the write part in this function, it is currently in the `prove_brainfuck` as `tree_builder.extend_evals(trace)`

I'm assuming that trying to convert an empty `MemoryTable` to a `Trace` for the Memory component should not be possible, it means that the execution trace is empty (compared to the I/O tables where it would simply mean no inputs nor output instruction)

About the `log_size`, when using the SimdBackend, the `LOG_N_LANES` be appended to the size of the trace, but I'm not so sure, to be confirmed. 
The `Claim` should be on the log_size of the `MemoryTable`, or the `log_size` appended with `LOG_N_LANES`?
I think that it is the MemoryTable one, but still unsure.