### PR TITLE
implement `From<Vec<Registers>>` to `ProcessorTable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ We try to follow these guidelines.
 - Memory is fixed at 30,000 cells by default, but is configurable.
 - Memory wraps on overflow/underflow.
   - It can be used for memory value `mv` and memory pointer `mp`,
-  but it will usually panic for `mp` as the memory size will be much smaller than $2^{31} - 1$.
+    but it will usually panic for `mp` as the memory size will be much smaller than $2^{31} - 1$.
 - Inputs are line-buffered (ends with the linefeed ASCII character `10`).
 - CLI uses Stdin and Stdout for IO.
 - For library use, input can be simulated by any reader (e.g. `Cursor`) and
-output with any writer (e.g. a custom writer).
+  output with any writer (e.g. a custom writer).
 
 ## Acknowledgements
 
@@ -33,7 +33,11 @@ and sibling article from Neptune Cash[^4].
 The Brainfuck compiler and interpreter have been adapted from rkdud007[^5]
 
 [^1]: [Brainfuck Language](https://esolangs.org/wiki/Brainfuck)
+
 [^2]: [Stwo repository](https://github.com/starkware-libs/stwo)
+
 [^3]: [BrainSTARK - Alan Szepieniec](https://aszepieniec.github.io/stark-brainfuck/)
+
 [^4]: [BrainSTARK - Neptune Cash](https://neptune.cash/learn/brainfuck-tutorial)
+
 [^5]: [rkdud007 brainfuck-zkvm repo](https://github.com/rkdud007/brainfuck-zkvm)

--- a/crates/brainfuck_prover/src/components/processor/table.rs
+++ b/crates/brainfuck_prover/src/components/processor/table.rs
@@ -34,18 +34,6 @@ pub struct ProcessorTableRow {
     mvi: BaseField,
 }
 
-impl ProcessorTableRow {
-    /// Creates a row for the [`ProcessorTable`] which is considered 'dummy'.
-    ///
-    /// A 'dummy' row, is a row that is not part of the execution trace from the Brainfuck program
-    /// execution.
-    /// They are used for padding and filling the  gaps after sorting by `clk`, to enforce the
-    /// correct sorting.
-    pub fn new_dummy(clk: BaseField, ip: BaseField) -> Self {
-        Self { clk, ip, ..Default::default() }
-    }
-}
-
 impl From<&Registers> for ProcessorTableRow {
     fn from(registers: &Registers) -> Self {
         Self {
@@ -111,10 +99,11 @@ impl ProcessorTable {
             let trace_len = self.table.len();
             let padding_offset = (trace_len.next_power_of_two() - trace_len) as u32;
             for i in 1..=padding_offset {
-                self.add_row(ProcessorTableRow::new_dummy(
-                    last_row.clk + BaseField::from(i),
-                    last_row.ip,
-                ));
+                self.add_row(ProcessorTableRow {
+                    clk: last_row.clk + BaseField::from(i),
+                    ip: last_row.ip,
+                    ..Default::default()
+                });
             }
         }
     }
@@ -124,7 +113,7 @@ impl From<Vec<Registers>> for ProcessorTable {
     fn from(registers: Vec<Registers>) -> Self {
         let mut processor_table = Self::new();
 
-        let rows = registers.iter().map(|x| x.into()).collect();
+        let rows = registers.iter().map(Into::into).collect();
         processor_table.add_rows(rows);
         processor_table.pad();
 

--- a/crates/brainfuck_prover/src/components/processor/table.rs
+++ b/crates/brainfuck_prover/src/components/processor/table.rs
@@ -1,5 +1,4 @@
 use brainfuck_vm::registers::Registers;
-use num_traits::Zero;
 use stwo_prover::core::fields::m31::BaseField;
 
 /// Represents a single row in the Processor Table.
@@ -43,15 +42,7 @@ impl ProcessorTableRow {
     /// They are used for padding and filling the `clk` gaps after sorting by `mp`, to enforce the
     /// correct sorting.
     pub fn new_dummy(clk: BaseField, ip: BaseField) -> Self {
-        Self {
-            clk,
-            ip,
-            ci: BaseField::zero(),
-            ni: BaseField::zero(),
-            mp: BaseField::zero(),
-            mv: BaseField::zero(),
-            mvi: BaseField::zero(),
-        }
+        Self { clk, ip, ..Default::default() }
     }
 }
 

--- a/crates/brainfuck_prover/src/components/processor/table.rs
+++ b/crates/brainfuck_prover/src/components/processor/table.rs
@@ -1,4 +1,5 @@
 use brainfuck_vm::registers::Registers;
+use num_traits::Zero;
 use stwo_prover::core::fields::m31::BaseField;
 
 /// Represents a single row in the Processor Table.
@@ -32,6 +33,26 @@ pub struct ProcessorTableRow {
     /// Memory value inverse: the modular inverse of `mv` on the cell values' range (over
     /// [`BaseField`])
     mvi: BaseField,
+}
+
+impl ProcessorTableRow {
+    /// Creates a row for the [`MemoryTable`] which is considered 'dummy'.
+    ///
+    /// A 'dummy' row, is a row that is not part of the execution trace from the Brainfuck program
+    /// execution.
+    /// They are used for padding and filling the `clk` gaps after sorting by `mp`, to enforce the
+    /// correct sorting.
+    pub fn new_dummy(clk: BaseField, ip: BaseField) -> Self {
+        Self {
+            clk,
+            ip,
+            ci: BaseField::zero(),
+            ni: BaseField::zero(),
+            mp: BaseField::zero(),
+            mv: BaseField::zero(),
+            mvi: BaseField::zero(),
+        }
+    }
 }
 
 impl From<&Registers> for ProcessorTableRow {
@@ -78,13 +99,57 @@ impl ProcessorTable {
     pub fn add_row(&mut self, row: ProcessorTableRow) {
         self.table.push(row);
     }
+
+    /// Adds multiple rows to the Processor Table.
+    ///
+    /// # Arguments
+    /// * `rows` - A vector of [`ProcessorTableRow`] to add to the table.
+    ///
+    /// This method extends the `table` vector with the provided rows.
+    fn add_rows(&mut self, rows: Vec<ProcessorTableRow>) {
+        self.table.extend(rows);
+    }
+
+    /// Pads the Processor table with dummy rows up to the next power of two length.
+    ///
+    /// Each dummy row increase clk, preserve ip, set others to zero.
+    ///
+    /// Does nothing if the table is empty.
+    fn pad(&mut self) {
+        if let Some(last_row) = self.table.last().cloned() {
+            let trace_len = self.table.len();
+            let padding_offset = (trace_len.next_power_of_two() - trace_len) as u32;
+            for i in 1..=padding_offset {
+                // TODO: i think ip should change in padding but trace returning like this
+                self.add_row(ProcessorTableRow::new_dummy(
+                    last_row.clk + BaseField::from(i),
+                    last_row.ip,
+                ));
+            }
+        }
+    }
+}
+
+impl From<Vec<Registers>> for ProcessorTable {
+    fn from(registers: Vec<Registers>) -> Self {
+        let mut processor_table = Self::new();
+
+        let rows = registers.iter().map(|x| x.into()).collect();
+        processor_table.add_rows(rows);
+        processor_table.pad();
+
+        processor_table
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use brainfuck_vm::registers::Registers;
+    use brainfuck_vm::{
+        compiler::Compiler, registers::Registers, test_helper::create_test_machine,
+    };
     use num_traits::{One, Zero};
+    use stwo_prover::core::fields::FieldExpOps;
 
     #[test]
     fn test_processor_table_row_from_registers() {
@@ -178,5 +243,155 @@ mod tests {
         }
 
         assert_eq!(processor_table.table, rows,);
+    }
+
+    #[test]
+    fn test_processor_table_from_registers_example_program() {
+        // Create a small program and compile it
+        let code = "+>,<[>+.<-]";
+        let mut compiler = Compiler::new(code);
+        let instructions = compiler.compile();
+        // Create a machine and execute the program
+        let (mut machine, _) = create_test_machine(&instructions, &[1]);
+        let () = machine.execute().expect("Failed to execute machine");
+
+        // Get the trace of the executed program
+        let trace = machine.trace();
+
+        // Convert the trace to an `ProcessorTable`
+        let processor_table: ProcessorTable = trace.into();
+
+        // Create the expected `ProcessorTable`
+        let process_0 = ProcessorTableRow {
+            clk: BaseField::zero(),
+            ip: BaseField::zero(),
+            ci: BaseField::from(43),
+            ni: BaseField::from(62),
+            mp: BaseField::zero(),
+            mv: BaseField::zero(),
+            mvi: BaseField::zero(),
+        };
+
+        let process_1 = ProcessorTableRow {
+            clk: BaseField::one(),
+            ip: BaseField::one(),
+            ci: BaseField::from(62),
+            ni: BaseField::from(44),
+            mp: BaseField::zero(),
+            mv: BaseField::one(),
+            mvi: BaseField::one(),
+        };
+
+        let process_2 = ProcessorTableRow {
+            clk: BaseField::from(2),
+            ip: BaseField::from(2),
+            ci: BaseField::from(44),
+            ni: BaseField::from(60),
+            mp: BaseField::one(),
+            mv: BaseField::zero(),
+            mvi: BaseField::zero(),
+        };
+
+        let process_3 = ProcessorTableRow {
+            clk: BaseField::from(3),
+            ip: BaseField::from(3),
+            ci: BaseField::from(60),
+            ni: BaseField::from(91),
+            mp: BaseField::one(),
+            mv: BaseField::one(),
+            mvi: BaseField::one(),
+        };
+
+        let process_4 = ProcessorTableRow {
+            clk: BaseField::from(4),
+            ip: BaseField::from(4),
+            ci: BaseField::from(91),
+            ni: BaseField::from(12),
+            mp: BaseField::zero(),
+            mv: BaseField::one(),
+            mvi: BaseField::one(),
+        };
+
+        let process_5 = ProcessorTableRow {
+            clk: BaseField::from(5),
+            ip: BaseField::from(6),
+            ci: BaseField::from(62),
+            ni: BaseField::from(43),
+            mp: BaseField::zero(),
+            mv: BaseField::one(),
+            mvi: BaseField::one(),
+        };
+
+        let process_6 = ProcessorTableRow {
+            clk: BaseField::from(6),
+            ip: BaseField::from(7),
+            ci: BaseField::from(43),
+            ni: BaseField::from(46),
+            mp: BaseField::one(),
+            mv: BaseField::one(),
+            mvi: BaseField::one(),
+        };
+
+        let process_7 = ProcessorTableRow {
+            clk: BaseField::from(7),
+            ip: BaseField::from(8),
+            ci: BaseField::from(46),
+            ni: BaseField::from(60),
+            mp: BaseField::one(),
+            mv: BaseField::from(2),
+            mvi: BaseField::from(2).inverse(),
+        };
+
+        let process_8 = ProcessorTableRow {
+            clk: BaseField::from(8),
+            ip: BaseField::from(9),
+            ci: BaseField::from(60),
+            ni: BaseField::from(45),
+            mp: BaseField::one(),
+            mv: BaseField::from(2),
+            mvi: BaseField::from(2).inverse(),
+        };
+
+        let process_9 = ProcessorTableRow {
+            clk: BaseField::from(9),
+            ip: BaseField::from(10),
+            ci: BaseField::from(45),
+            ni: BaseField::from(93),
+            mp: BaseField::zero(),
+            mv: BaseField::one(),
+            mvi: BaseField::one(),
+        };
+
+        let process_10 = ProcessorTableRow {
+            clk: BaseField::from(10),
+            ip: BaseField::from(11),
+            ci: BaseField::from(93),
+            ni: BaseField::from(6),
+            mp: BaseField::zero(),
+            mv: BaseField::zero(),
+            mvi: BaseField::zero(),
+        };
+
+        let process_11 = ProcessorTableRow {
+            clk: BaseField::from(11),
+            ip: BaseField::from(13),
+            ci: BaseField::zero(),
+            ni: BaseField::zero(),
+            mp: BaseField::zero(),
+            mv: BaseField::zero(),
+            mvi: BaseField::zero(),
+        };
+
+        let mut expected_processor_table = ProcessorTable {
+            table: vec![
+                process_0, process_1, process_2, process_3, process_4, process_5, process_6,
+                process_7, process_8, process_9, process_10, process_11,
+            ],
+        };
+
+        expected_processor_table.pad();
+
+        // Verify that the processor table is correct
+        assert_eq!(processor_table, expected_processor_table);
     }
 }

--- a/crates/brainfuck_prover/src/components/processor/table.rs
+++ b/crates/brainfuck_prover/src/components/processor/table.rs
@@ -224,6 +224,7 @@ mod tests {
         assert_eq!(processor_table.table, rows,);
     }
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn test_processor_table_from_registers_example_program() {
         // Create a small program and compile it
@@ -341,7 +342,7 @@ mod tests {
             mvi: BaseField::one(),
         };
 
-        let process_10 = ProcessorTableRow {
+        let process_no_10 = ProcessorTableRow {
             clk: BaseField::from(10),
             ip: BaseField::from(11),
             ci: BaseField::from(93),
@@ -351,7 +352,7 @@ mod tests {
             mvi: BaseField::zero(),
         };
 
-        let process_11 = ProcessorTableRow {
+        let process_no_11 = ProcessorTableRow {
             clk: BaseField::from(11),
             ip: BaseField::from(13),
             ci: BaseField::zero(),
@@ -363,8 +364,18 @@ mod tests {
 
         let mut expected_processor_table = ProcessorTable {
             table: vec![
-                process_0, process_1, process_2, process_3, process_4, process_5, process_6,
-                process_7, process_8, process_9, process_10, process_11,
+                process_0,
+                process_1,
+                process_2,
+                process_3,
+                process_4,
+                process_5,
+                process_6,
+                process_7,
+                process_8,
+                process_9,
+                process_no_10,
+                process_no_11,
             ],
         };
 

--- a/crates/brainfuck_prover/src/components/processor/table.rs
+++ b/crates/brainfuck_prover/src/components/processor/table.rs
@@ -35,11 +35,11 @@ pub struct ProcessorTableRow {
 }
 
 impl ProcessorTableRow {
-    /// Creates a row for the [`MemoryTable`] which is considered 'dummy'.
+    /// Creates a row for the [`ProcessorTable`] which is considered 'dummy'.
     ///
     /// A 'dummy' row, is a row that is not part of the execution trace from the Brainfuck program
     /// execution.
-    /// They are used for padding and filling the `clk` gaps after sorting by `mp`, to enforce the
+    /// They are used for padding and filling the  gaps after sorting by `clk`, to enforce the
     /// correct sorting.
     pub fn new_dummy(clk: BaseField, ip: BaseField) -> Self {
         Self { clk, ip, ..Default::default() }
@@ -103,7 +103,7 @@ impl ProcessorTable {
 
     /// Pads the Processor table with dummy rows up to the next power of two length.
     ///
-    /// Each dummy row increase clk, preserve ip, set others to zero.
+    /// Each dummy row increase clk, copy the others from the last step
     ///
     /// Does nothing if the table is empty.
     fn pad(&mut self) {
@@ -111,7 +111,6 @@ impl ProcessorTable {
             let trace_len = self.table.len();
             let padding_offset = (trace_len.next_power_of_two() - trace_len) as u32;
             for i in 1..=padding_offset {
-                // TODO: i think ip should change in padding but trace returning like this
                 self.add_row(ProcessorTableRow::new_dummy(
                     last_row.clk + BaseField::from(i),
                     last_row.ip,

--- a/crates/brainfuck_prover/src/components/processor/table.rs
+++ b/crates/brainfuck_prover/src/components/processor/table.rs
@@ -101,8 +101,7 @@ impl ProcessorTable {
             for i in 1..=padding_offset {
                 self.add_row(ProcessorTableRow {
                     clk: last_row.clk + BaseField::from(i),
-                    ip: last_row.ip,
-                    ..Default::default()
+                    ..last_row.clone()
                 });
             }
         }

--- a/crates/brainfuck_vm/src/bin/brainfuck_vm.rs
+++ b/crates/brainfuck_vm/src/bin/brainfuck_vm.rs
@@ -45,9 +45,6 @@ fn main() -> Result<(), MachineError> {
     tracing::info!("Provide inputs separated by linefeeds: ");
     bf_vm.execute().unwrap();
     if args.trace {
-        if args.pad_trace {
-            bf_vm.pad_trace();
-        };
         let trace = bf_vm.trace();
         tracing::info!("Execution trace: {:#?}", trace);
     }

--- a/crates/brainfuck_vm/src/bin/brainfuck_vm.rs
+++ b/crates/brainfuck_vm/src/bin/brainfuck_vm.rs
@@ -21,8 +21,6 @@ struct Args {
     #[clap(long)]
     trace: bool,
     #[clap(long)]
-    pad_trace: bool,
-    #[clap(long)]
     ram_size: Option<usize>,
 }
 

--- a/crates/brainfuck_vm/src/machine.rs
+++ b/crates/brainfuck_vm/src/machine.rs
@@ -241,19 +241,6 @@ impl Machine {
         self.trace.clone()
     }
 
-    pub fn pad_trace(&mut self) {
-        let last_register = &self.state.registers;
-        let trace_len = self.trace.len() as u32;
-        let padding_offset = trace_len.next_power_of_two() + 1 - trace_len;
-        for i in 1..padding_offset {
-            let dummy = Registers {
-                clk: BaseField::from(last_register.clk.0 + i),
-                ..last_register.clone()
-            };
-            self.trace.push(dummy);
-        }
-    }
-
     pub const fn program(&self) -> &ProgramMemory {
         &self.program
     }
@@ -437,61 +424,6 @@ mod tests {
         };
 
         assert_eq!(trace, vec![initial_state, intermediate_state, final_state]);
-        Ok(())
-    }
-
-    #[test]
-    fn test_pad_trace() -> Result<(), MachineError> {
-        // '++'
-        let code = vec![BaseField::from(43), BaseField::from(43)];
-        let (mut machine, _) = create_test_machine(&code, &[]);
-        machine.execute()?;
-
-        // Initial state + executed instructions
-        let trace = machine.trace();
-        let initial_state = Registers {
-            clk: BaseField::zero(),
-            ip: BaseField::zero(),
-            ci: BaseField::from(43),
-            ni: BaseField::from(43),
-            mp: BaseField::zero(),
-            mv: BaseField::zero(),
-            mvi: BaseField::zero(),
-        };
-        let intermediate_state = Registers {
-            clk: BaseField::one(),
-            ip: BaseField::one(),
-            ci: BaseField::from(43),
-            ni: BaseField::zero(),
-            mp: BaseField::zero(),
-            mv: BaseField::one(),
-            mvi: BaseField::one(),
-        };
-        let final_state = Registers {
-            clk: BaseField::from(2),
-            ip: BaseField::from(2),
-            ci: BaseField::zero(),
-            ni: BaseField::zero(),
-            mp: BaseField::zero(),
-            mv: BaseField::from(2),
-            mvi: BaseField::from(2).inverse(),
-        };
-
-        assert_eq!(trace.len(), 3);
-        assert_eq!(trace[0], initial_state);
-        assert_eq!(trace[1], intermediate_state);
-        assert_eq!(trace[2], final_state);
-
-        machine.pad_trace();
-        let trace = machine.trace();
-        let dummy = Registers { clk: final_state.clk + BaseField::one(), ..final_state };
-
-        assert_eq!(trace.len(), 4);
-        assert_eq!(trace[0], initial_state);
-        assert_eq!(trace[1], intermediate_state);
-        assert_eq!(trace[2], final_state);
-        assert_eq!(trace[3], dummy);
-
         Ok(())
     }
 }


### PR DESCRIPTION
resolving #68 

question 1: i'm not sure which step is handling adding & computing extension columns and also still not sure why we cannot have { }Table to contain full trace including registers + extension columns.

question 2: `ip` should change on padded rows  (base on Alan's tutorial) but our current machine return trace as keep last `ip` to be consistent on followup padded rows - is It expected? also added comment as //TODO for this 