### PR TITLE
refactor: constant to preprocessed trace

### DIFF
--- a/crates/brainfuck_prover/src/components/memory/component.rs
+++ b/crates/brainfuck_prover/src/components/memory/component.rs
@@ -25,9 +25,15 @@ impl Claim {
     ///
     /// NOTE: Currently only the main trace is provided.
     pub fn log_sizes(&self) -> TreeVec<Vec<u32>> {
-        // TODO: Add the preprocessed and interaction trace sizes
+        // TODO: Add the preprocessed and interaction trace correct sizes
+        let preprocessed_trace_log_sizes: Vec<u32> = vec![];
         let trace_log_sizes = vec![self.log_size; MemoryColumn::count()];
-        TreeVec::new(vec![trace_log_sizes])
+        let interaction_trace_log_sizes: Vec<u32> = vec![];
+        TreeVec::new(vec![
+            preprocessed_trace_log_sizes,
+            trace_log_sizes,
+            interaction_trace_log_sizes,
+        ])
     }
 
     /// Mix the log size of the Memory table to the Fiat-Shamir [`Channel`],


### PR DESCRIPTION
Closes #72 for good

I've added mocked preprocessed and interaction log size to the Claim of the Memory component, so that the log size of the main trace (now interaction phase 1 while being phase 0 before) is at the right place in the TreeVec