### PR TITLE
fix: use rust system toolchain for trunk check

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,12 +20,9 @@ runtimes:
     - go@1.21.0
     - node@18.12.1
     - python@3.10.8
-downloads:
-  - name: rust
-    downloads:
-      - os: linux
-        url: https://static.rust-lang.org/dist/2024-01-04/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
-        strip_components: 2
+  definitions:
+    - type: rust
+      system_version: allowed
 lint:
   definitions:
     - name: clippy
@@ -35,8 +32,8 @@ lint:
   enabled:
     - actionlint@1.7.4
     - checkov@3.2.278
-    - rustfmt@2024-01-04
-    - clippy@2024-01-04
+    - rustfmt@SYSTEM
+    - clippy@SYSTEM
     - git-diff-check
     - markdownlint@0.42.0
     - osv-scanner@1.9.1


### PR DESCRIPTION
When running `trunk check`, depending on the os/cpu architecture rust would not be properly downloaded (as the previous trunk.yaml rust download only targetted linux)