### PR TITLE
fix: add rust toolchain update to trunk ci

### DIFF
--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -18,5 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - run: rustup update
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: "true"
+
       - name: Trunk Code Quality
         uses: trunk-io/trunk-action@v1

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -23,12 +23,6 @@ runtimes:
   definitions:
     - type: rust
       system_version: allowed
-downloads:
-  - name: rust
-    downloads:
-      - os: linux
-        url: https://static.rust-lang.org/dist/2024-01-04/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
-        strip_components: 2
 lint:
   definitions:
     - name: clippy

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -23,6 +23,12 @@ runtimes:
   definitions:
     - type: rust
       system_version: allowed
+downloads:
+  - name: rust
+    downloads:
+      - os: linux
+        url: https://static.rust-lang.org/dist/2024-01-04/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
+        strip_components: 2
 lint:
   definitions:
     - name: clippy

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -190,6 +190,12 @@ impl MemoryTable {
     ///
     /// # Arguments
     /// * memory - The [`MemoryTable`] containing the sorted and padded trace as an array of rows.
+    ///
+    /// # Returns
+    /// A tuple containing the evaluated trace and claim for STARK proof.
+    ///
+    /// # Errors
+    /// Returns [`TraceError::EmptyTrace`] if the table is empty.
     pub fn trace_evaluation(&self) -> Result<(TraceEval, Claim), TraceError> {
         let n_rows = self.table.len() as u32;
         if n_rows == 0 {


### PR DESCRIPTION
Having the system version pinned for local use, it requires updating the toolchain in the ci (with `rustup update` before running `trunk check` in the gh action)