### PR TITLE
feat: add interaction trace evaluation

### DIFF
--- a/crates/brainfuck_prover/src/brainfuck_air/mod.rs
+++ b/crates/brainfuck_prover/src/brainfuck_air/mod.rs
@@ -201,7 +201,7 @@ pub fn verify_brainfuck(
     // Check that the lookup sum is valid, otherwise throw
     // TODO: panic! should be replaced by custom error
     if !lookup_sum_valid(&claim, &interaction_elements, &interaction_claim) {
-        return Err(VerificationError::InvalidLookup("Invalid logup sum".to_string()));
+        return Err(VerificationError::InvalidLookup("Invalid LogUp sum".to_string()));
     };
     interaction_claim.mix_into(channel);
     commitment_scheme_verifier.commit(proof.commitments[1], &sizes[1], channel);

--- a/crates/brainfuck_prover/src/components/memory/component.rs
+++ b/crates/brainfuck_prover/src/components/memory/component.rs
@@ -55,6 +55,7 @@ impl Claim {
 /// of the Processor trace (which is the execution trace provided by the `brainfuck_vm`).
 #[derive(Debug, Eq, PartialEq)]
 pub struct InteractionClaim {
+    /// The computed sum of the logUp extension column, including padded rows.
     pub claimed_sum: SecureField,
 }
 

--- a/crates/brainfuck_prover/src/components/memory/component.rs
+++ b/crates/brainfuck_prover/src/components/memory/component.rs
@@ -57,6 +57,7 @@ impl Claim {
 pub struct InteractionClaim {
     pub claimed_sum: SecureField,
 }
+
 impl InteractionClaim {
     /// Mix the sums from the logUp protocol into the Fiat-Shamir [`Channel`],
     /// to bound the proof to the trace.

--- a/crates/brainfuck_prover/src/components/memory/component.rs
+++ b/crates/brainfuck_prover/src/components/memory/component.rs
@@ -1,8 +1,5 @@
 use super::table::MemoryColumn;
-use stwo_prover::{
-    constraint_framework::logup::ClaimedPrefixSum,
-    core::{channel::Channel, fields::qm31::SecureField, pcs::TreeVec},
-};
+use stwo_prover::core::{channel::Channel, fields::qm31::SecureField, pcs::TreeVec};
 
 /// The claim for the Memory component
 #[derive(Debug, Eq, PartialEq)]
@@ -46,33 +43,20 @@ impl Claim {
     }
 }
 
-/// The claim of the interaction phase 2 (with the LogUp protocol).
+/// The claim of the interaction phase 2 (with the logUp protocol).
 ///
-/// The total sum is the computed sum of the LogUp extension column,
+/// The total sum is the computed sum of the logUp extension column,
 /// including the padded rows.
 /// It allows proving that the Memory main trace is a permutation
-/// of the Processor trace (which is the execution trace provided by the brainfuck_vm).
-///
-/// The [`ClaimedPrefixSum`] is the sum of the 'real' rows (i.e. without the padding rows).
-/// The total sum and the claimed sum should be equal.
+/// of the Processor trace (which is the execution trace provided by the `brainfuck_vm`).
 #[derive(Debug, Eq, PartialEq)]
 pub struct InteractionClaim {
-    pub total_sum: SecureField,
-    pub claimed_sum: Option<ClaimedPrefixSum>,
+    pub claimed_sum: SecureField,
 }
 impl InteractionClaim {
-    /// Mix the sums from the LogUp protocol into the Fiat-Shamir [`Channel`],
+    /// Mix the sums from the logUp protocol into the Fiat-Shamir [`Channel`],
     /// to bound the proof to the trace.
-    ///
-    /// If the trace has been padded, both the total sum and the claimed
-    /// sum are mixed, as well as the index in the extension column
-    /// where the claimed_sum is.
     pub fn mix_into(&self, channel: &mut impl Channel) {
-        if let Some((claimed_sum, claimed_index)) = self.claimed_sum {
-            channel.mix_felts(&[self.total_sum, claimed_sum]);
-            channel.mix_u64(claimed_index as u64);
-        } else {
-            channel.mix_felts(&[self.total_sum]);
-        }
+        channel.mix_felts(&[self.claimed_sum]);
     }
 }

--- a/crates/brainfuck_prover/src/components/memory/component.rs
+++ b/crates/brainfuck_prover/src/components/memory/component.rs
@@ -1,5 +1,9 @@
 use super::table::MemoryColumn;
-use stwo_prover::core::{channel::Channel, fields::qm31::SecureField, pcs::TreeVec};
+use stwo_prover::core::{
+    channel::Channel,
+    fields::{qm31::SecureField, secure_column::SECURE_EXTENSION_DEGREE},
+    pcs::TreeVec,
+};
 
 /// The claim for the Memory component
 #[derive(Debug, Eq, PartialEq)]
@@ -28,7 +32,7 @@ impl Claim {
         // TODO: Add the preprocessed and interaction trace correct sizes
         let preprocessed_trace_log_sizes: Vec<u32> = vec![];
         let trace_log_sizes = vec![self.log_size; MemoryColumn::count()];
-        let interaction_trace_log_sizes: Vec<u32> = vec![];
+        let interaction_trace_log_sizes: Vec<u32> = vec![self.log_size; SECURE_EXTENSION_DEGREE];
         TreeVec::new(vec![
             preprocessed_trace_log_sizes,
             trace_log_sizes,

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -327,6 +327,16 @@ impl<F: Clone, EF: RelationEFTraitBound<F>> Relation<F, EF> for MemoryElements {
 /// Creates the interaction trace from the main trace evaluation
 /// and the interaction elements for the Memory component.
 ///
+/// The Processor component uses the other components:
+/// The Processor component multiplicities are then positive,
+/// and the Memory component multiplicities are negative
+/// in the logup protocol.
+///
+/// Only the 'real' rows are impacting the logup sum.
+/// Dummy rows are padded rows and rows filling the `clk` gaps
+/// which does not appear in the Processor main trace.
+///
+///
 /// # Returns
 /// - Interaction trace evaluation, to be commited.
 /// - Interaction claim: the total sum from the logup protocol,
@@ -349,9 +359,6 @@ pub fn interaction_trace_evaluation(
         let mp = mp_col[vec_row];
         let mv = mv_column[vec_row];
         // Set the fraction numerator to 0 if it is a dummy row (d = 1), otherwise set it to -1.
-        // The numerator multiplicity is negative as the Memory component is yielding
-        // while the Processor component is using the Memory component:
-        // the related column in the Processor component has a numerator of positive multiplicity.
         let is_dummy_num = PackedSecureField::from(d_col[vec_row]) - PackedSecureField::one();
         // Only the common registers with the processor table are part of the extension column.
         let denom: PackedSecureField = lookup_elements.combine(&[clk, mp, mv]);

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -650,8 +650,8 @@ mod tests {
 
         let num_1 = -PackedSecureField::one();
         let num_2 = PackedSecureField::zero();
-        let num_3 = num_1;
-        let num_4 = num_2;
+        let num_3 = -PackedSecureField::one();
+        let num_4 = PackedSecureField::zero();
 
         col_gen.write_frac(0, num_1, denoms[0]);
         col_gen.write_frac(1, num_2, denoms[1]);

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -276,9 +276,9 @@ impl MemoryColumn {
 
 /// The interaction elements drawn for the extension column of the Memory component.
 ///
-/// The logup protocol uses these elements to combine the values of the different
+/// The logUp protocol uses these elements to combine the values of the different
 /// registers of the main trace to create a random linear combination
-/// of them, and use it in the denominator of the fractions in the logup protocol.
+/// of them, and use it in the denominator of the fractions in the logUp protocol.
 ///
 /// There are 3 lookup elements in the Memory component, as only the 'real' registers
 /// are used: `clk`, `mp` and `mv`. `d` is used to eventually nullify the numerator.
@@ -294,7 +294,7 @@ impl MemoryElements {
     /// Draw random elements from the Fiat-Shamir [`Channel`].
     ///
     /// These elements are randomly secured, and will be use
-    /// to generate the interaction trace with the logup protocol.
+    /// to generate the interaction trace with the logUp protocol.
     pub fn draw(channel: &mut impl Channel) -> Self {
         Self(LookupElements::draw(channel))
     }
@@ -330,16 +330,16 @@ impl<F: Clone, EF: RelationEFTraitBound<F>> Relation<F, EF> for MemoryElements {
 /// The Processor component uses the other components:
 /// The Processor component multiplicities are then positive,
 /// and the Memory component multiplicities are negative
-/// in the logup protocol.
+/// in the logUp protocol.
 ///
-/// Only the 'real' rows are impacting the logup sum.
+/// Only the 'real' rows are impacting the logUp sum.
 /// Dummy rows are padded rows and rows filling the `clk` gaps
 /// which does not appear in the Processor main trace.
 ///
 ///
 /// # Returns
 /// - Interaction trace evaluation, to be commited.
-/// - Interaction claim: the total sum from the logup protocol,
+/// - Interaction claim: the total sum from the logUp protocol,
 /// to be mixed into the Fiat-Shamir [`Channel`].
 pub fn interaction_trace_evaluation(
     main_trace_eval: &TraceEval,
@@ -638,7 +638,7 @@ mod tests {
         let clk_col = &trace_eval[MemoryColumn::Clk.index()].data;
         let mp_col = &trace_eval[MemoryColumn::Mp.index()].data;
         let mv_column = &trace_eval[MemoryColumn::Mv.index()].data;
-        // Construct the denominator for each row of the logup column, from the main trace
+        // Construct the denominator for each row of the logUp column, from the main trace
         // evaluation.
         for vec_row in 0..1 << (log_size - LOG_N_LANES) {
             let clk = clk_col[vec_row];
@@ -676,7 +676,7 @@ mod tests {
     }
 
     // This test verifies that the dummy rows have no impact
-    // on the total sum of the logup protocol in the Memory component.
+    // on the total sum of the logUp protocol in the Memory component.
     // Indeed, the total sum computed by the Processor component won't
     // have the exact same dummy rows (the Memory component) adds extra
     // dummy rows to fill the `clk` jumps and enforce the sorting.

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -361,9 +361,8 @@ pub fn interaction_trace_evaluation(
     col_gen.finalize_col();
 
     let (trace, claimed_sum) = logup_gen.finalize_last();
-    let interaction_claim = InteractionClaim { claimed_sum };
 
-    (trace, interaction_claim)
+    (trace, InteractionClaim { claimed_sum })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #89, #90

The interaction trace for the Memory components allows proving that the Memory Component main trace is a permutation of the Processor main trace.

Stwo has defined a `relation!` macro to avoid having to implement custom `LookupElements<N>` as we did for `MemoryElements`, but it is a private macro (`pub(crate)`) so we cannot use it for now.