### PR TITLE
refactor: memory table

### DIFF
--- a/crates/brainfuck_prover/src/brainfuck_air/mod.rs
+++ b/crates/brainfuck_prover/src/brainfuck_air/mod.rs
@@ -198,7 +198,8 @@ pub fn prove_brainfuck(
     let mut tree_builder = commitment_scheme.tree_builder();
 
     let (memory_interaction_trace_eval, memory_interaction_claim) =
-        interaction_trace_evaluation(&memory_trace, &interaction_elements.memory_lookup_elements);
+        interaction_trace_evaluation(&memory_trace, &interaction_elements.memory_lookup_elements)
+            .unwrap();
 
     tree_builder.extend_evals(memory_interaction_trace_eval);
 

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -114,6 +114,7 @@ impl From<Vec<Registers>> for MemoryTable {
 }
 
 // Separated from `Vec<Registers> for MemoryTable` to facilitate tests.
+// It is assumed that [`MemoryIntermediateTable`] is sorted and padded to the next power of two.
 impl From<MemoryIntermediateTable> for MemoryTable {
     fn from(mut intermediate_table: MemoryIntermediateTable) -> Self {
         let mut memory_table = Self::new();

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -669,22 +669,23 @@ mod tests {
     #[test]
     fn test_complete_wih_dummy_entries() {
         let mut intermediate_table = MemoryIntermediateTable::new();
-        let row1 = MemoryTableEntry::new(BaseField::zero(), BaseField::zero(), BaseField::zero());
-        let row2 = MemoryTableEntry::new(BaseField::zero(), BaseField::one(), BaseField::zero());
-        let row3 = MemoryTableEntry::new(BaseField::from(5), BaseField::one(), BaseField::one());
-        intermediate_table.add_entries(vec![row3.clone(), row1.clone(), row2.clone()]);
+        let entry_1 =
+            MemoryTableEntry::new(BaseField::zero(), BaseField::zero(), BaseField::zero());
+        let entry_2 = MemoryTableEntry::new(BaseField::zero(), BaseField::one(), BaseField::zero());
+        let entry_3 = MemoryTableEntry::new(BaseField::from(5), BaseField::one(), BaseField::one());
+        intermediate_table.add_entries(vec![entry_3.clone(), entry_1.clone(), entry_2.clone()]);
         intermediate_table.sort();
         intermediate_table.complete_with_dummy_entries();
 
         let mut expected_memory_table = MemoryIntermediateTable::new();
         expected_memory_table.add_entries(vec![
-            row1,
-            row2,
+            entry_1,
+            entry_2,
             MemoryTableEntry::new_dummy(BaseField::one(), BaseField::one(), BaseField::zero()),
             MemoryTableEntry::new_dummy(BaseField::from(2), BaseField::one(), BaseField::zero()),
             MemoryTableEntry::new_dummy(BaseField::from(3), BaseField::one(), BaseField::zero()),
             MemoryTableEntry::new_dummy(BaseField::from(4), BaseField::one(), BaseField::zero()),
-            row3,
+            entry_3,
         ]);
 
         assert_eq!(intermediate_table, expected_memory_table);
@@ -700,17 +701,18 @@ mod tests {
     #[test]
     fn test_pad() {
         let mut intermediate_table = MemoryIntermediateTable::new();
-        let row1 = MemoryTableEntry::new(BaseField::zero(), BaseField::zero(), BaseField::zero());
-        let row2 = MemoryTableEntry::new(BaseField::one(), BaseField::one(), BaseField::zero());
-        let row3 = MemoryTableEntry::new(BaseField::from(2), BaseField::one(), BaseField::one());
-        intermediate_table.add_entries(vec![row1.clone(), row2.clone(), row3.clone()]);
+        let entry_1 =
+            MemoryTableEntry::new(BaseField::zero(), BaseField::zero(), BaseField::zero());
+        let entry_2 = MemoryTableEntry::new(BaseField::one(), BaseField::one(), BaseField::zero());
+        let entry_3 = MemoryTableEntry::new(BaseField::from(2), BaseField::one(), BaseField::one());
+        intermediate_table.add_entries(vec![entry_1.clone(), entry_2.clone(), entry_3.clone()]);
 
         intermediate_table.pad();
 
         let dummy_entry =
             MemoryTableEntry::new_dummy(BaseField::from(3), BaseField::one(), BaseField::one());
         let mut expected_memory_table = MemoryIntermediateTable::new();
-        expected_memory_table.add_entries(vec![row1, row2, row3, dummy_entry]);
+        expected_memory_table.add_entries(vec![entry_1, entry_2, entry_3, dummy_entry]);
 
         assert_eq!(intermediate_table, expected_memory_table);
     }
@@ -815,18 +817,18 @@ mod tests {
     #[test]
     fn test_interaction_trace_evaluation() {
         let mut intermediate_table = MemoryIntermediateTable::new();
-        // Trace rows are:
-        // - Real row
-        // - Dummy row (filling the `clk` value)
-        // - Real row
-        // - Dummy row (padding to the power of 2)
-        let rows = vec![
+        // Trace entries are:
+        // - Real entry
+        // - Dummy entry (filling the `clk` value)
+        // - Real entry
+        // - Dummy entry (padding to the power of 2)
+        let entries = vec![
             MemoryTableEntry::new(BaseField::zero(), BaseField::zero(), BaseField::zero()),
             MemoryTableEntry::new_dummy(BaseField::one(), BaseField::one(), BaseField::zero()),
             MemoryTableEntry::new(BaseField::from(2), BaseField::one(), BaseField::zero()),
             MemoryTableEntry::new_dummy(BaseField::from(3), BaseField::one(), BaseField::zero()),
         ];
-        intermediate_table.add_entries(rows);
+        intermediate_table.add_entries(entries);
 
         let memory_table = MemoryTable::from(intermediate_table);
 
@@ -882,22 +884,22 @@ mod tests {
         assert_eq!(interaction_claim.claimed_sum, expected_claimed_sum);
     }
 
-    // This test verifies that the dummy rows have no impact
+    // This test verifies that the dummy entries have no impact
     // on the total sum of the logUp protocol in the Memory component.
     // Indeed, the total sum computed by the Processor component won't
-    // have the exact same dummy rows (the Memory component) adds extra
-    // dummy rows to fill the `clk` jumps and enforce the sorting.
+    // have the exact same dummy entries: the Memory component adds extra
+    // dummy entries to fill the `clk` jumps and enforce the sorting.
     #[test]
-    fn test_interaction_trace_evaluation_dummy_rows_effect() {
+    fn test_interaction_trace_evaluation_dummy_entries_effect() {
         let mut intermediate_table = MemoryIntermediateTable::new();
         let mut real_intermediate_table = MemoryIntermediateTable::new();
 
-        // Trace rows are:
-        // - Real row
-        // - Dummy row (filling the `clk` value)
-        // - Real row
-        // - Dummy row (padding to power of 2)
-        let rows = vec![
+        // Trace entries are:
+        // - Real entry
+        // - Dummy entry (filling the `clk` value)
+        // - Real entry
+        // - Dummy entry (padding to power of 2)
+        let entries = vec![
             MemoryTableEntry::new(BaseField::zero(), BaseField::from(43), BaseField::from(91)),
             MemoryTableEntry::new_dummy(BaseField::one(), BaseField::from(43), BaseField::from(91)),
             MemoryTableEntry::new(BaseField::from(2), BaseField::from(91), BaseField::from(9)),
@@ -907,16 +909,16 @@ mod tests {
                 BaseField::from(9),
             ),
         ];
-        intermediate_table.add_entries(rows);
+        intermediate_table.add_entries(entries);
 
-        // Trace rows are:
-        // - Real row
-        // - Real row
-        let real_rows = vec![
+        // Trace entries are:
+        // - Real entry
+        // - Real entry
+        let real_entries = vec![
             MemoryTableEntry::new(BaseField::zero(), BaseField::from(43), BaseField::from(91)),
             MemoryTableEntry::new(BaseField::from(2), BaseField::from(91), BaseField::from(9)),
         ];
-        real_intermediate_table.add_entries(real_rows);
+        real_intermediate_table.add_entries(real_entries);
 
         let (trace_eval, _) = MemoryTable::from(intermediate_table).trace_evaluation().unwrap();
         let (new_trace_eval, _) =

--- a/crates/brainfuck_prover/src/components/memory/table.rs
+++ b/crates/brainfuck_prover/src/components/memory/table.rs
@@ -25,7 +25,7 @@ use stwo_prover::{
 /// from the execution trace provided by the Brainfuck Virtual Machine,
 /// then sorting by `mp` as a primary key and by `clk` as a secondary key.
 ///
-/// To enforce the sorting on clk, all clk jumped are erased by adding dummy rows.
+/// To enforce the sorting on `clk`, all `clk` jumped are erased by adding dummy rows.
 /// A dummy column flags them.
 ///
 /// To ease constraints evaluation, each row of the Memory component
@@ -166,7 +166,7 @@ pub struct MemoryTableRow {
     next_clk: BaseField,
     /// Next Memory pointer.
     next_mp: BaseField,
-    /// Memory value.
+    /// Next Memory value.
     next_mv: BaseField,
     /// Next Dummy.
     next_d: BaseField,
@@ -197,7 +197,7 @@ impl MemoryTableRow {
 /// It allows extracting the required fields from the execution trace provided by the Brainfuck
 /// Virtual Machine, then sorting by `mp` as a primary key and by `clk` as a secondary key.
 ///
-/// To enforce the sorting on clk, all clk jumped are erased by adding dummy entries.
+/// To enforce the sorting on `clk`, all `clk` jumped are erased by adding dummy entries.
 /// A dummy column flags these entries.
 ///
 /// To be used by [`MemoryTable`].
@@ -560,9 +560,9 @@ mod tests {
 
     #[test]
     fn test_memory_row_new() {
-        let entry_1: MemoryTableEntry =
+        let entry_1 =
             MemoryTableEntry::new(BaseField::zero(), BaseField::from(43), BaseField::from(91));
-        let entry_2: MemoryTableEntry =
+        let entry_2 =
             MemoryTableEntry::new_dummy(BaseField::one(), BaseField::from(3), BaseField::from(9));
 
         let row = MemoryTableRow::new(&entry_1, &entry_2);
@@ -725,7 +725,7 @@ mod tests {
             mv: BaseField::one(),
             ..Default::default()
         };
-        let registers: Vec<Registers> = vec![reg_3, reg_1, reg_2];
+        let registers = vec![reg_3, reg_1, reg_2];
 
         let entry_1 = MemoryTableEntry::default();
         let entry_2 = MemoryTableEntry::new(BaseField::one(), BaseField::one(), BaseField::zero());


### PR DESCRIPTION
Refactorization of the Memory table linked to the flattening of the transition constraints into a single row, to avoid bit-reversals.

The Memory component trace is now
| clk | mp | mv | d | next_clk | next_mp | next_mv | next_d |
| --- | --- | --- | --- | --- | --- | --- | --- |

I've chosen to keep the table structure we had as an intermediary representation between `Vec<Registers>` and `MemoryTable`.

| Previously | Refactorization |
| --- | --- |
| `MemoryTableRow` | `MemoryTableEntry`
| `MemoryTable` | `MemoryIntermediateTable`

The `MemoryTableRow` and `MemoryTable` are re-used for the final trace of the memory component.
This way, filling the `clk` jumps with `complete_with_dummy_rows`, the sorting and the padding is done on the `MemoryIntermediateTable`. And we just need to pair the consecutive entries in the implementation of `MemoryTable` where the trace evaluation is done.

Assuming that the `MemoryIntermediateTable.table` has been padded to a power of 2, when pairing the consecutive rows, we then need to add one dummy entry for the last `MemoryTableRow` of the `MemoryTable` to be correctly padded.
